### PR TITLE
Improve configuration flexibility and add file download functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,11 @@
 # SharePoint設定
-SHAREPOINT_SITE_URL=https://yourcompany.sharepoint.com/sites/yoursite
+SHAREPOINT_BASE_URL=https://yourcompany.sharepoint.com
 SHAREPOINT_TENANT_ID=your-tenant-id-here
 SHAREPOINT_CLIENT_ID=your-client-id-here
+
+# SHAREPOINT_SITE_NAMEを指定すると特定のサイトのみを対象にします
+# 空にするとテナント全体を対象にしますが、セキュリティ上の理由から推奨されません
+# SHAREPOINT_SITE_NAME=yoursite
 
 # 証明書認証設定（ファイルパスまたはテキストのいずれかを指定）
 # 優先順位: 1. テキスト、2. ファイルパス

--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ uv sync --dev
 
 ```bash
 # SharePoint設定
-SHAREPOINT_SITE_URL=https://yourcompany.sharepoint.com/sites/yoursite
+SHAREPOINT_BASE_URL=https://yourcompany.sharepoint.com
+SHAREPOINT_SITE_NAME=yoursite
 SHAREPOINT_TENANT_ID=your-tenant-id-here
 SHAREPOINT_CLIENT_ID=your-client-id-here
+
+# SHAREPOINT_SITE_NAME を空にするとテナント全体を検索対象にできます
+# SHAREPOINT_SITE_NAME=
 
 # 証明書認証設定（ファイルパスまたはテキストのいずれかを指定）
 # 優先順位: 1. テキスト、2. ファイルパス
@@ -186,7 +190,8 @@ Claude Desktopと統合するには、設定ファイルを更新してくださ
       "args": ["run", "sharepoint-docs-mcp", "--transport", "stdio"],
       "cwd": "/path/to/sharepoint-docs-mcp",
       "env": {
-        "SHAREPOINT_SITE_URL": "https://yourcompany.sharepoint.com/sites/yoursite",
+        "SHAREPOINT_BASE_URL": "https://yourcompany.sharepoint.com",
+        "SHAREPOINT_SITE_NAME": "yoursite",
         "SHAREPOINT_TENANT_ID": "your-tenant-id-here",
         "SHAREPOINT_CLIENT_ID": "your-client-id-here",
         "SHAREPOINT_CERTIFICATE_PATH": "./cert/certificate.pem",

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,10 @@ class SharePointConfig:
 
     def __init__(self):
         # SharePoint設定
-        self.site_url = os.getenv("SHAREPOINT_SITE_URL", "")
+        self.base_url = os.getenv(
+            "SHAREPOINT_BASE_URL", ""
+        )  # https://company.sharepoint.com
+        self.site_name = os.getenv("SHAREPOINT_SITE_NAME", "")  # sitename（オプション）
         self.tenant_id = os.getenv("SHAREPOINT_TENANT_ID", "")
         self.client_id = os.getenv("SHAREPOINT_CLIENT_ID", "")
 
@@ -34,6 +37,18 @@ class SharePointConfig:
             os.getenv("SHAREPOINT_ALLOWED_FILE_EXTENSIONS", "pdf,docx,xlsx,pptx,txt")
         )
 
+    @property
+    def site_url(self) -> str:
+        """サイトURLを取得（サイト名が指定されている場合のみ）"""
+        if self.site_name:
+            return f"{self.base_url}/sites/{self.site_name}"
+        return self.base_url
+
+    @property
+    def is_site_specific(self) -> bool:
+        """特定のサイトに限定されているかどうか"""
+        return bool(self.site_name)
+
     def _parse_file_extensions(self, extensions_str: str) -> list[str]:
         """ファイル拡張子文字列をリストに変換"""
         if not extensions_str:
@@ -44,8 +59,8 @@ class SharePointConfig:
         """設定の検証を行い、エラーメッセージのリストを返す"""
         errors = []
 
-        if not self.site_url:
-            errors.append("SHAREPOINT_SITE_URL is required")
+        if not self.base_url:
+            errors.append("SHAREPOINT_BASE_URL is required")
 
         if not self.tenant_id:
             errors.append("SHAREPOINT_TENANT_ID is required")


### PR DESCRIPTION
## Summary
- Add `sharepoint_docs_download` tool for downloading files from search results
- Implement flexible configuration with `SHAREPOINT_BASE_URL` and `SHAREPOINT_SITE_NAME`
- Support both site-specific and tenant-wide search scopes
- Remove `get_system_info` tool (unnecessary for SharePoint functionality)
- Update documentation and configuration examples

## Changes
### New Features
- **File Download**: Added `sharepoint_docs_download` tool to download files found via `sharepoint_docs_search`
- **Flexible Configuration**: Separated base URL and site name for better flexibility
- **Scope Control**: Can now search specific sites or entire tenant

### Configuration Changes
- `SHAREPOINT_SITE_URL` → `SHAREPOINT_BASE_URL` + `SHAREPOINT_SITE_NAME` (optional)
- Site-specific search when `SHAREPOINT_SITE_NAME` is provided
- Tenant-wide search when `SHAREPOINT_SITE_NAME` is empty

### Removed Features
- Removed `get_system_info` tool (not relevant to SharePoint document management)

## Test plan
- [x] Test site-specific search and download
- [x] Test configuration validation
- [ ] Test tenant-wide search (if permissions allow)
- [ ] Verify download works with different file types

🤖 Generated with [Claude Code](https://claude.ai/code)