### PR TITLE
test: add comprehensive pytest testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ uv run sharepoint-docs-mcp --help
 
 ### Development Commands
 
+**Testing**
+```bash
+# Run tests
+uv run test
+
+# Run tests with coverage report
+uv run test --cov=src --cov-report=html
+```
+
 **Code quality checks**
 ```bash
 # Lint (static analysis)
@@ -181,7 +190,7 @@ uv run lint
 # Type checking (ty)
 uv run typecheck
 
-# All checks (type checking + lint)
+# All checks (type checking + lint + tests)
 uv run check
 ```
 
@@ -200,12 +209,22 @@ uv run fix
 sharepoint-docs-mcp/
 ├── src/
 │   ├── __init__.py
-│   ├── server.py       # MCP server core logic
-│   └── main.py         # CLI entry point
-├── scripts.py          # Development utility commands
-├── pyproject.toml      # Project configuration
-├── README.md           # English documentation
-└── README_ja.md        # Japanese documentation
+│   ├── server.py            # MCP server core logic
+│   ├── main.py              # CLI entry point
+│   ├── config.py            # Configuration management
+│   ├── sharepoint_auth.py   # Azure AD authentication
+│   ├── sharepoint_search.py # SharePoint search client
+│   └── error_messages.py    # Error handling
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py          # Test fixtures and mocks
+│   ├── test_config.py       # Configuration tests
+│   ├── test_server.py       # Server functionality tests
+│   └── test_error_messages.py # Error handling tests
+├── scripts.py               # Development utility commands
+├── pyproject.toml           # Project configuration and dependencies
+├── README.md                # English documentation
+└── README_ja.md             # Japanese documentation
 ```
 
 ## Claude Desktop Integration
@@ -257,6 +276,13 @@ In this case, place the configuration in the `.env` file at the project root.
 
 ## Development
 
+### Testing Framework
+
+- **pytest**: Python testing framework with fixtures and mocking
+- **pytest-cov**: Code coverage reporting
+- **pytest-mock**: Enhanced mocking capabilities
+- 24 unit tests covering core functionality (48% coverage)
+
 ### Code Quality Tools
 
 - **ruff**: Fast Python linter and formatter
@@ -265,6 +291,7 @@ In this case, place the configuration in the `.env` file at the project root.
 ### Configuration Files
 
 - `pyproject.toml`: Project configuration, dependencies, development tool settings
+- pytest configuration: Test discovery and coverage settings
 - ruff configuration: Code style and rule settings
 - ty configuration: Detailed type checking settings
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -173,6 +173,15 @@ uv run sharepoint-docs-mcp --help
 
 ### 開発用コマンド
 
+**テスト**
+```bash
+# テスト実行
+uv run test
+
+# カバレッジレポート付きテスト実行
+uv run test --cov=src --cov-report=html
+```
+
 **コード品質チェック**
 ```bash
 # Lint（静的解析）
@@ -181,7 +190,7 @@ uv run lint
 # 型チェック（ty）
 uv run typecheck
 
-# 全体チェック（型チェック + lint）
+# 全体チェック（型チェック + lint + テスト）
 uv run check
 ```
 
@@ -200,11 +209,22 @@ uv run fix
 sharepoint-docs-mcp/
 ├── src/
 │   ├── __init__.py
-│   ├── server.py       # MCPサーバーのコアロジック
-│   └── main.py         # CLIエントリポイント
-├── scripts.py          # 開発用ユーティリティコマンド
-├── pyproject.toml      # プロジェクト設定
-└── README.md
+│   ├── server.py            # MCPサーバーのコアロジック
+│   ├── main.py              # CLIエントリポイント
+│   ├── config.py            # 設定管理
+│   ├── sharepoint_auth.py   # Azure AD認証
+│   ├── sharepoint_search.py # SharePoint検索クライアント
+│   └── error_messages.py    # エラーハンドリング
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py          # テストフィクスチャとモック
+│   ├── test_config.py       # 設定管理のテスト
+│   ├── test_server.py       # サーバー機能のテスト
+│   └── test_error_messages.py # エラーハンドリングのテスト
+├── scripts.py               # 開発用ユーティリティコマンド
+├── pyproject.toml           # プロジェクト設定と依存関係
+├── README.md                # 英語ドキュメント
+└── README_ja.md             # 日本語ドキュメント
 ```
 
 ## Claude Desktop との統合
@@ -257,6 +277,13 @@ Claude Desktopと統合するには、設定ファイルを更新してくださ
 
 ## 開発
 
+### テストフレームワーク
+
+- **pytest**: フィクスチャとモック機能を持つPythonテストフレームワーク
+- **pytest-cov**: コードカバレッジレポート
+- **pytest-mock**: 強化されたモック機能
+- 主要機能をカバーする24のユニットテスト（カバレッジ48%）
+
 ### コード品質ツール
 
 - **ruff**: 高速なPythonリンター・フォーマッター
@@ -265,6 +292,7 @@ Claude Desktopと統合するには、設定ファイルを更新してくださ
 ### 設定ファイル
 
 - `pyproject.toml`: プロジェクト設定、依存関係、開発ツールの設定
+- pytest設定: テスト発見とカバレッジ設定
 - ruff設定: コードスタイル、ルール設定
 - ty設定: 型チェックの詳細設定
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ dev = [
     "ruff>=0.8.0",
     "ty>=0.0.1a16",
 ]
+test = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-mock>=3.12.0",
+]
 
 [project.scripts]
 sharepoint-docs-mcp = "src.main:app"
@@ -28,6 +33,7 @@ fmt = "scripts:format"
 fix = "scripts:fix"
 typecheck = "scripts:type_check"
 check = "scripts:check"
+test = "scripts:test"
 
 [tool.uv]
 package = true
@@ -74,3 +80,21 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+    "--cov=src",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+]
+markers = [
+    "unit: Unit tests",
+    "integration: Integration tests",
+    "slow: Slow running tests",
+]

--- a/scripts.py
+++ b/scripts.py
@@ -56,15 +56,34 @@ def type_check():
 
 
 
+def test():
+    """
+    pytestでテストを実行する
+    """
+    print("🧪 テストを実行中...")
+    cmd = ["pytest", "-v"]
+    result = subprocess.run(cmd)
+
+    if result.returncode == 0:
+        print("✅ すべてのテストが成功しました！")
+    else:
+        print("❌ テストが失敗しました")
+
+    exit(result.returncode)
+
+
 def check():
     """
-    型チェック、Lintを同時に実行する（修正はしない）
+    型チェック、Lint、テストを同時に実行する（修正はしない）
     """
     print("🔍 型チェックを実行中...")
     type_result = subprocess.run(["ty", "check"] + QUALITY_CHECK_DIRS, capture_output=True)
 
     print("📝 Lintを実行中...")
     lint_result = subprocess.run(["ruff", "check"] + QUALITY_CHECK_DIRS, capture_output=True)
+
+    print("🧪 テストを実行中...")
+    test_result = subprocess.run(["pytest", "-v", "--tb=short"], capture_output=True)
 
     # 結果をまとめて表示
     print("\n" + "=" * 50)
@@ -73,9 +92,11 @@ def check():
 
     type_status = "✅ PASS" if type_result.returncode == 0 else "❌ FAIL"
     lint_status = "✅ PASS" if lint_result.returncode == 0 else "❌ FAIL"
+    test_status = "✅ PASS" if test_result.returncode == 0 else "❌ FAIL"
 
     print(f"型チェック: {type_status}")
     print(f"Lint:       {lint_status}")
+    print(f"テスト:     {test_status}")
 
     # エラーがある場合は詳細を表示
     if type_result.returncode != 0:
@@ -88,8 +109,13 @@ def check():
         print(lint_result.stdout.decode())
         print(lint_result.stderr.decode())
 
+    if test_result.returncode != 0:
+        print("\n🧪 テストエラー:")
+        print(test_result.stdout.decode())
+        print(test_result.stderr.decode())
+
     # いずれかが失敗した場合は非ゼロで終了
-    if any(result.returncode != 0 for result in [type_result, lint_result]):
+    if any(result.returncode != 0 for result in [type_result, lint_result, test_result]):
         exit(1)
     else:
         print("\n🎉 すべてのチェックが成功しました！")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+from unittest.mock import Mock, patch
+import os
+from src.config import SharePointConfig
+
+
+@pytest.fixture
+def mock_config():
+    """Mock SharePoint configuration for testing"""
+    config = Mock(spec=SharePointConfig)
+    config.site_url = "https://test.sharepoint.com/sites/test"
+    config.tenant_id = "test-tenant-id"
+    config.client_id = "test-client-id"
+    config.certificate_path = None
+    config.certificate_text = "mock-certificate"
+    config.private_key_path = None
+    config.private_key_text = "mock-private-key"
+    config.default_max_results = 20
+    config.allowed_file_extensions = ["pdf", "docx", "xlsx"]
+    config.search_tool_description = "Test search tool"
+    config.download_tool_description = "Test download tool"
+
+    # Mock validation method
+    config.validate.return_value = []
+
+    return config
+
+
+@pytest.fixture
+def mock_env_vars():
+    """Mock environment variables for testing"""
+    env_vars = {
+        "SHAREPOINT_BASE_URL": "https://test.sharepoint.com",
+        "SHAREPOINT_SITE_NAME": "test",
+        "SHAREPOINT_TENANT_ID": "test-tenant-id",
+        "SHAREPOINT_CLIENT_ID": "test-client-id",
+        "SHAREPOINT_CERTIFICATE_TEXT": "mock-certificate",
+        "SHAREPOINT_PRIVATE_KEY_TEXT": "mock-private-key",
+    }
+
+    with patch.dict(os.environ, env_vars, clear=False):
+        yield env_vars
+
+
+@pytest.fixture
+def mock_sharepoint_auth():
+    """Mock SharePoint authentication"""
+    with patch("src.sharepoint_auth.SharePointCertificateAuth") as mock_auth:
+        auth_instance = Mock()
+        auth_instance.get_access_token.return_value = "mock-access-token"
+        mock_auth.return_value = auth_instance
+        yield auth_instance
+
+
+@pytest.fixture
+def mock_sharepoint_client():
+    """Mock SharePoint search client"""
+    with patch("src.sharepoint_search.SharePointSearchClient") as mock_client:
+        client_instance = Mock()
+        client_instance.search_documents.return_value = [
+            {
+                "title": "Test Document 1",
+                "path": "/sites/test/documents/test1.pdf",
+                "size": 1024,
+                "modified": "2024-01-01T00:00:00Z",
+                "extension": "pdf",
+                "summary": "Test document summary",
+            }
+        ]
+        client_instance.download_file.return_value = b"mock file content"
+        mock_client.return_value = client_instance
+        yield client_instance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import patch, mock_open
+import os
+
+from src.config import SharePointConfig
+
+
+class TestSharePointConfig:
+    """SharePointConfig のテスト"""
+
+    def test_valid_config_from_env(self, mock_env_vars):
+        """環境変数から有効な設定を読み込むテスト"""
+        config = SharePointConfig()
+        validation_errors = config.validate()
+
+        assert validation_errors == []
+        assert config.site_url == "https://test.sharepoint.com/sites/test"
+        assert config.tenant_id == "test-tenant-id"
+        assert config.client_id == "test-client-id"
+
+    def test_missing_required_env_vars(self):
+        """必須の環境変数が不足している場合のテスト"""
+        with patch.dict(os.environ, {}, clear=True):
+            config = SharePointConfig()
+            validation_errors = config.validate()
+
+            assert len(validation_errors) > 0
+            assert any("SHAREPOINT_TENANT_ID is required" in error for error in validation_errors)
+            assert any("SHAREPOINT_CLIENT_ID is required" in error for error in validation_errors)
+
+    def test_certificate_text_priority_over_file(self):
+        """証明書テキストがファイルパスより優先されることのテスト"""
+        env_vars = {
+            "SHAREPOINT_BASE_URL": "https://test.sharepoint.com",
+            "SHAREPOINT_SITE_NAME": "test",
+            "SHAREPOINT_TENANT_ID": "test-tenant-id",
+            "SHAREPOINT_CLIENT_ID": "test-client-id",
+            "SHAREPOINT_CERTIFICATE_PATH": "/path/to/cert.pem",
+            "SHAREPOINT_CERTIFICATE_TEXT": "certificate-text",
+            "SHAREPOINT_PRIVATE_KEY_PATH": "/path/to/key.pem",
+            "SHAREPOINT_PRIVATE_KEY_TEXT": "private-key-text",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = SharePointConfig()
+
+            assert config.certificate_text == "certificate-text"
+            assert config.private_key_text == "private-key-text"
+            assert config.certificate_path == "/path/to/cert.pem"
+            assert config.private_key_path == "/path/to/key.pem"
+
+    def test_file_extensions_parsing(self):
+        """ファイル拡張子のパースのテスト"""
+        env_vars = {
+            "SHAREPOINT_BASE_URL": "https://test.sharepoint.com",
+            "SHAREPOINT_SITE_NAME": "test",
+            "SHAREPOINT_TENANT_ID": "test-tenant-id",
+            "SHAREPOINT_CLIENT_ID": "test-client-id",
+            "SHAREPOINT_CERTIFICATE_TEXT": "cert",
+            "SHAREPOINT_PRIVATE_KEY_TEXT": "key",
+            "SHAREPOINT_ALLOWED_FILE_EXTENSIONS": "pdf,docx,xlsx,pptx",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = SharePointConfig()
+
+            assert config.allowed_file_extensions == ["pdf", "docx", "xlsx", "pptx"]
+
+    def test_default_values(self):
+        """デフォルト値のテスト"""
+        env_vars = {
+            "SHAREPOINT_BASE_URL": "https://test.sharepoint.com",
+            "SHAREPOINT_SITE_NAME": "test",
+            "SHAREPOINT_TENANT_ID": "test-tenant-id",
+            "SHAREPOINT_CLIENT_ID": "test-client-id",
+            "SHAREPOINT_CERTIFICATE_TEXT": "cert",
+            "SHAREPOINT_PRIVATE_KEY_TEXT": "key",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = SharePointConfig()
+
+            assert config.default_max_results == 20
+            assert "pdf" in config.allowed_file_extensions
+            assert "Search for documents in SharePoint" in config.search_tool_description
+            assert "Download a file from SharePoint" in config.download_tool_description
+
+    @pytest.mark.unit
+    def test_empty_site_name_creates_tenant_url(self):
+        """サイト名が空の場合、テナント全体のURLが作成されることのテスト"""
+        env_vars = {
+            "SHAREPOINT_BASE_URL": "https://test.sharepoint.com",
+            "SHAREPOINT_SITE_NAME": "",  # Empty site name
+            "SHAREPOINT_TENANT_ID": "test-tenant-id",
+            "SHAREPOINT_CLIENT_ID": "test-client-id",
+            "SHAREPOINT_CERTIFICATE_TEXT": "cert",
+            "SHAREPOINT_PRIVATE_KEY_TEXT": "key",
+        }
+
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = SharePointConfig()
+
+            assert config.site_url == "https://test.sharepoint.com"

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import Mock
+import requests
+
+from src.error_messages import handle_sharepoint_error
+
+
+class TestHandleSharePointError:
+    """handle_sharepoint_error 関数のテスト"""
+
+    @pytest.mark.unit
+    def test_http_error_401(self):
+        """401 Unauthorized エラーのテスト"""
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+
+        result = handle_sharepoint_error(http_error, "search")
+
+        assert "authentication" in str(result).lower()
+        assert "configuration" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_http_error_403(self):
+        """403 Forbidden エラーのテスト"""
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_response.text = "Forbidden"
+
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+
+        result = handle_sharepoint_error(http_error, "search")
+
+        assert "access" in str(result).lower() or "denied" in str(result).lower()
+        assert "permission" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_http_error_404(self):
+        """404 Not Found エラーのテスト"""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Not Found"
+
+        http_error = requests.HTTPError()
+        http_error.response = mock_response
+
+        result = handle_sharepoint_error(http_error, "search")
+
+        assert "error" in str(result).lower()
+        assert "configuration" in str(result).lower() or "administrator" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_connection_error(self):
+        """接続エラーのテスト"""
+        connection_error = requests.ConnectionError("Connection failed")
+
+        result = handle_sharepoint_error(connection_error, "search")
+
+        assert "connection" in str(result).lower() or "network" in str(result).lower()
+        assert "sharepoint" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_timeout_error(self):
+        """タイムアウトエラーのテスト"""
+        timeout_error = requests.Timeout("Request timed out")
+
+        result = handle_sharepoint_error(timeout_error, "search")
+
+        assert "error" in str(result).lower()
+        assert "configuration" in str(result).lower() or "administrator" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_certificate_error(self):
+        """証明書関連エラーのテスト"""
+        cert_error = Exception("Certificate file not found")
+
+        result = handle_sharepoint_error(cert_error, "search")
+
+        assert "certificate" in str(result).lower()
+        assert "configured" in str(result).lower() or "configuration" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_generic_error(self):
+        """一般的なエラーのテスト"""
+        generic_error = Exception("Something went wrong")
+
+        result = handle_sharepoint_error(generic_error, "search")
+
+        assert "unexpected error" in str(result).lower()
+        assert "configuration" in str(result).lower() or "administrator" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_download_context_specific_message(self):
+        """ダウンロード操作固有のエラーメッセージテスト"""
+        generic_error = Exception("Download failed")
+
+        result = handle_sharepoint_error(generic_error, "download")
+
+        assert "error" in str(result).lower()
+        assert "configuration" in str(result).lower() or "administrator" in str(result).lower()
+
+    @pytest.mark.unit
+    def test_http_error_without_response(self):
+        """レスポンスオブジェクトがないHTTPエラーのテスト"""
+        http_error = requests.HTTPError("HTTP Error without response")
+
+        result = handle_sharepoint_error(http_error, "search")
+
+        assert "error" in str(result).lower()
+        assert "configuration" in str(result).lower() or "administrator" in str(result).lower()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,162 @@
+import pytest
+from unittest.mock import patch, Mock
+import base64
+
+from src.server import sharepoint_docs_search, sharepoint_docs_download
+
+
+class TestSharePointDocsSearch:
+    """sharepoint_docs_search 関数のテスト"""
+
+    @pytest.mark.unit
+    def test_search_with_default_parameters(self, mock_config, mock_sharepoint_client):
+        """デフォルトパラメータでの検索テスト"""
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                results = sharepoint_docs_search("test query")
+
+                assert len(results) == 1
+                assert results[0]["title"] == "Test Document 1"
+                assert results[0]["path"] == "/sites/test/documents/test1.pdf"
+                mock_sharepoint_client.search_documents.assert_called_once_with(
+                    query="test query",
+                    max_results=20,
+                    file_extensions=None,
+                )
+
+    @pytest.mark.unit
+    def test_search_with_compact_format(self, mock_config, mock_sharepoint_client):
+        """コンパクトフォーマットでの検索テスト"""
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                results = sharepoint_docs_search("test query", response_format="compact")
+
+                assert len(results) == 1
+                assert "title" in results[0]
+                assert "path" in results[0]
+                assert "extension" in results[0]
+                # コンパクトフォーマットでは以下のフィールドは含まれない
+                assert "size" not in results[0]
+                assert "modified" not in results[0]
+                assert "summary" not in results[0]
+
+    @pytest.mark.unit
+    def test_search_with_invalid_response_format(self, mock_config, mock_sharepoint_client):
+        """無効なresponse_formatでの検索テスト（デフォルトにフォールバック）"""
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                results = sharepoint_docs_search("test query", response_format="invalid")
+
+                # 無効なフォーマットはdetailedにフォールバックするため、全フィールドが含まれる
+                assert len(results) == 1
+                assert "title" in results[0]
+                assert "size" in results[0]
+                assert "modified" in results[0]
+
+    @pytest.mark.unit
+    def test_search_with_file_extensions(self, mock_config, mock_sharepoint_client):
+        """ファイル拡張子フィルタでの検索テスト"""
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                results = sharepoint_docs_search(
+                    "test query",
+                    file_extensions=["pdf", "docx"]
+                )
+
+                mock_sharepoint_client.search_documents.assert_called_once_with(
+                    query="test query",
+                    max_results=20,
+                    file_extensions=["pdf", "docx"],
+                )
+
+    @pytest.mark.unit
+    def test_search_max_results_limit(self, mock_config, mock_sharepoint_client):
+        """最大結果数の制限テスト"""
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                sharepoint_docs_search("test query", max_results=150)
+
+                # 100を超える値は100に制限される
+                mock_sharepoint_client.search_documents.assert_called_once_with(
+                    query="test query",
+                    max_results=100,
+                    file_extensions=None,
+                )
+
+
+class TestSharePointDocsDownload:
+    """sharepoint_docs_download 関数のテスト"""
+
+    @pytest.mark.unit
+    def test_download_file(self, mock_config, mock_sharepoint_client):
+        """ファイルダウンロードのテスト"""
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                result = sharepoint_docs_download("/sites/test/documents/test.pdf")
+
+                expected_content = base64.b64encode(b"mock file content").decode("utf-8")
+                assert result == expected_content
+                mock_sharepoint_client.download_file.assert_called_once_with(
+                    "/sites/test/documents/test.pdf"
+                )
+
+    @pytest.mark.unit
+    def test_download_file_error_handling(self, mock_config, mock_sharepoint_client):
+        """ファイルダウンロードエラーハンドリングのテスト"""
+        mock_sharepoint_client.download_file.side_effect = Exception("Download failed")
+
+        with patch("src.server._get_sharepoint_client", return_value=mock_sharepoint_client):
+            with patch("src.server.config", mock_config):
+                with pytest.raises(Exception) as exc_info:
+                    sharepoint_docs_download("/sites/test/documents/test.pdf")
+
+                # エラーハンドリング関数が呼ばれることを確認
+                assert "Download failed" in str(exc_info.value.__cause__)
+
+
+class TestGetSharePointClient:
+    """_get_sharepoint_client 関数のテスト"""
+
+    @pytest.mark.unit
+    def test_client_initialization(self, mock_config):
+        """SharePointクライアントの初期化テスト"""
+        with patch("src.server.config", mock_config):
+            with patch("src.server.SharePointCertificateAuth") as mock_auth_class:
+                with patch("src.server.SharePointSearchClient") as mock_client_class:
+                    from src.server import _get_sharepoint_client
+
+                    # グローバル変数をリセット
+                    import src.server
+                    src.server._sharepoint_client = None
+
+                    client = _get_sharepoint_client()
+
+                    mock_auth_class.assert_called_once_with(
+                        tenant_id=mock_config.tenant_id,
+                        client_id=mock_config.client_id,
+                        site_url=mock_config.site_url,
+                        certificate_path=mock_config.certificate_path,
+                        certificate_text=mock_config.certificate_text,
+                        private_key_path=mock_config.private_key_path,
+                        private_key_text=mock_config.private_key_text,
+                    )
+                    mock_client_class.assert_called_once()
+
+    @pytest.mark.unit
+    def test_client_singleton_behavior(self, mock_config):
+        """SharePointクライアントのシングルトン動作テスト"""
+        with patch("src.server.config", mock_config):
+            with patch("src.server.SharePointCertificateAuth"):
+                with patch("src.server.SharePointSearchClient") as mock_client_class:
+                    from src.server import _get_sharepoint_client
+
+                    # グローバル変数をリセット
+                    import src.server
+                    src.server._sharepoint_client = None
+
+                    client1 = _get_sharepoint_client()
+                    client2 = _get_sharepoint_client()
+
+                    # 2回目の呼び出しでは新しいインスタンスを作成しない
+                    assert mock_client_class.call_count == 1
+                    assert client1 == client2

--- a/uv.lock
+++ b/uv.lock
@@ -176,6 +176,70 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.10.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/70/025b179c993f019105b79575ac6edb5e084fb0f0e63f15cdebef4e454fb5/coverage-7.10.6.tar.gz", hash = "sha256:f644a3ae5933a552a29dbb9aa2f90c677a875f80ebea028e5a52a4f429044b90", size = 823736, upload-time = "2025-08-29T15:35:16.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/06/263f3305c97ad78aab066d116b52250dd316e74fcc20c197b61e07eb391a/coverage-7.10.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b2dd6059938063a2c9fee1af729d4f2af28fd1a545e9b7652861f0d752ebcea", size = 217324, upload-time = "2025-08-29T15:33:29.06Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/60/1e1ded9a4fe80d843d7d53b3e395c1db3ff32d6c301e501f393b2e6c1c1f/coverage-7.10.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:388d80e56191bf846c485c14ae2bc8898aa3124d9d35903fef7d907780477634", size = 217560, upload-time = "2025-08-29T15:33:30.748Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/52136173c14e26dfed8b106ed725811bb53c30b896d04d28d74cb64318b3/coverage-7.10.6-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:90cb5b1a4670662719591aa92d0095bb41714970c0b065b02a2610172dbf0af6", size = 249053, upload-time = "2025-08-29T15:33:32.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1d/ae25a7dc58fcce8b172d42ffe5313fc267afe61c97fa872b80ee72d9515a/coverage-7.10.6-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:961834e2f2b863a0e14260a9a273aff07ff7818ab6e66d2addf5628590c628f9", size = 251802, upload-time = "2025-08-29T15:33:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7a/1f561d47743710fe996957ed7c124b421320f150f1d38523d8d9102d3e2a/coverage-7.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf9a19f5012dab774628491659646335b1928cfc931bf8d97b0d5918dd58033c", size = 252935, upload-time = "2025-08-29T15:33:34.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ad/8b97cd5d28aecdfde792dcbf646bac141167a5cacae2cd775998b45fabb5/coverage-7.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99c4283e2a0e147b9c9cc6bc9c96124de9419d6044837e9799763a0e29a7321a", size = 250855, upload-time = "2025-08-29T15:33:36.922Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6a/95c32b558d9a61858ff9d79580d3877df3eb5bc9eed0941b1f187c89e143/coverage-7.10.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:282b1b20f45df57cc508c1e033403f02283adfb67d4c9c35a90281d81e5c52c5", size = 248974, upload-time = "2025-08-29T15:33:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/8ce95dee640a38e760d5b747c10913e7a06554704d60b41e73fdea6a1ffd/coverage-7.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cdbe264f11afd69841bd8c0d83ca10b5b32853263ee62e6ac6a0ab63895f972", size = 250409, upload-time = "2025-08-29T15:33:39.447Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/7a55b0bdde78a98e2eb2356771fd2dcddb96579e8342bb52aa5bc52e96f0/coverage-7.10.6-cp312-cp312-win32.whl", hash = "sha256:a517feaf3a0a3eca1ee985d8373135cfdedfbba3882a5eab4362bda7c7cf518d", size = 219724, upload-time = "2025-08-29T15:33:41.172Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/32b185b8b8e327802c9efce3d3108d2fe2d9d31f153a0f7ecfd59c773705/coverage-7.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:856986eadf41f52b214176d894a7de05331117f6035a28ac0016c0f63d887629", size = 220536, upload-time = "2025-08-29T15:33:42.524Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3a/d5d8dc703e4998038c3099eaf77adddb00536a3cec08c8dcd556a36a3eb4/coverage-7.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:acf36b8268785aad739443fa2780c16260ee3fa09d12b3a70f772ef100939d80", size = 219171, upload-time = "2025-08-29T15:33:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e7/917e5953ea29a28c1057729c1d5af9084ab6d9c66217523fd0e10f14d8f6/coverage-7.10.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ffea0575345e9ee0144dfe5701aa17f3ba546f8c3bb48db62ae101afb740e7d6", size = 217351, upload-time = "2025-08-29T15:33:45.438Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/86/2e161b93a4f11d0ea93f9bebb6a53f113d5d6e416d7561ca41bb0a29996b/coverage-7.10.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:95d91d7317cde40a1c249d6b7382750b7e6d86fad9d8eaf4fa3f8f44cf171e80", size = 217600, upload-time = "2025-08-29T15:33:47.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/66/d03348fdd8df262b3a7fb4ee5727e6e4936e39e2f3a842e803196946f200/coverage-7.10.6-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e23dd5408fe71a356b41baa82892772a4cefcf758f2ca3383d2aa39e1b7a003", size = 248600, upload-time = "2025-08-29T15:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/508420fb47d09d904d962f123221bc249f64b5e56aa93d5f5f7603be475f/coverage-7.10.6-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f3f56e4cb573755e96a16501a98bf211f100463d70275759e73f3cbc00d4f27", size = 251206, upload-time = "2025-08-29T15:33:50.697Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1f/9020135734184f439da85c70ea78194c2730e56c2d18aee6e8ff1719d50d/coverage-7.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:db4a1d897bbbe7339946ffa2fe60c10cc81c43fab8b062d3fcb84188688174a4", size = 252478, upload-time = "2025-08-29T15:33:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a4/3d228f3942bb5a2051fde28c136eea23a761177dc4ff4ef54533164ce255/coverage-7.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d8fd7879082953c156d5b13c74aa6cca37f6a6f4747b39538504c3f9c63d043d", size = 250637, upload-time = "2025-08-29T15:33:53.67Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e3/293dce8cdb9a83de971637afc59b7190faad60603b40e32635cbd15fbf61/coverage-7.10.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:28395ca3f71cd103b8c116333fa9db867f3a3e1ad6a084aa3725ae002b6583bc", size = 248529, upload-time = "2025-08-29T15:33:55.022Z" },
+    { url = "https://files.pythonhosted.org/packages/90/26/64eecfa214e80dd1d101e420cab2901827de0e49631d666543d0e53cf597/coverage-7.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:61c950fc33d29c91b9e18540e1aed7d9f6787cc870a3e4032493bbbe641d12fc", size = 250143, upload-time = "2025-08-29T15:33:56.386Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/70/bd80588338f65ea5b0d97e424b820fb4068b9cfb9597fbd91963086e004b/coverage-7.10.6-cp313-cp313-win32.whl", hash = "sha256:160c00a5e6b6bdf4e5984b0ef21fc860bc94416c41b7df4d63f536d17c38902e", size = 219770, upload-time = "2025-08-29T15:33:58.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/14/0b831122305abcc1060c008f6c97bbdc0a913ab47d65070a01dc50293c2b/coverage-7.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:628055297f3e2aa181464c3808402887643405573eb3d9de060d81531fa79d32", size = 220566, upload-time = "2025-08-29T15:33:59.766Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c6/81a83778c1f83f1a4a168ed6673eeedc205afb562d8500175292ca64b94e/coverage-7.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:df4ec1f8540b0bcbe26ca7dd0f541847cc8a108b35596f9f91f59f0c060bfdd2", size = 219195, upload-time = "2025-08-29T15:34:01.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/1c/ccccf4bf116f9517275fa85047495515add43e41dfe8e0bef6e333c6b344/coverage-7.10.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c9a8b7a34a4de3ed987f636f71881cd3b8339f61118b1aa311fbda12741bff0b", size = 218059, upload-time = "2025-08-29T15:34:02.91Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/8a3ceff833d27c7492af4f39d5da6761e9ff624831db9e9f25b3886ddbca/coverage-7.10.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8dd5af36092430c2b075cee966719898f2ae87b636cefb85a653f1d0ba5d5393", size = 218287, upload-time = "2025-08-29T15:34:05.106Z" },
+    { url = "https://files.pythonhosted.org/packages/92/d8/50b4a32580cf41ff0423777a2791aaf3269ab60c840b62009aec12d3970d/coverage-7.10.6-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0353b0f0850d49ada66fdd7d0c7cdb0f86b900bb9e367024fd14a60cecc1e27", size = 259625, upload-time = "2025-08-29T15:34:06.575Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7e/6a7df5a6fb440a0179d94a348eb6616ed4745e7df26bf2a02bc4db72c421/coverage-7.10.6-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d6b9ae13d5d3e8aeca9ca94198aa7b3ebbc5acfada557d724f2a1f03d2c0b0df", size = 261801, upload-time = "2025-08-29T15:34:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/4c/a270a414f4ed5d196b9d3d67922968e768cd971d1b251e1b4f75e9362f75/coverage-7.10.6-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:675824a363cc05781b1527b39dc2587b8984965834a748177ee3c37b64ffeafb", size = 264027, upload-time = "2025-08-29T15:34:09.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/3210d663d594926c12f373c5370bf1e7c5c3a427519a8afa65b561b9a55c/coverage-7.10.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:692d70ea725f471a547c305f0d0fc6a73480c62fb0da726370c088ab21aed282", size = 261576, upload-time = "2025-08-29T15:34:11.585Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d0/e1961eff67e9e1dba3fc5eb7a4caf726b35a5b03776892da8d79ec895775/coverage-7.10.6-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:851430a9a361c7a8484a36126d1d0ff8d529d97385eacc8dfdc9bfc8c2d2cbe4", size = 259341, upload-time = "2025-08-29T15:34:13.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/06/d6478d152cd189b33eac691cba27a40704990ba95de49771285f34a5861e/coverage-7.10.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d9369a23186d189b2fc95cc08b8160ba242057e887d766864f7adf3c46b2df21", size = 260468, upload-time = "2025-08-29T15:34:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/73/737440247c914a332f0b47f7598535b29965bf305e19bbc22d4c39615d2b/coverage-7.10.6-cp313-cp313t-win32.whl", hash = "sha256:92be86fcb125e9bda0da7806afd29a3fd33fdf58fba5d60318399adf40bf37d0", size = 220429, upload-time = "2025-08-29T15:34:16.394Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/76/b92d3214740f2357ef4a27c75a526eb6c28f79c402e9f20a922c295c05e2/coverage-7.10.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6b3039e2ca459a70c79523d39347d83b73f2f06af5624905eba7ec34d64d80b5", size = 221493, upload-time = "2025-08-29T15:34:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8e/6dcb29c599c8a1f654ec6cb68d76644fe635513af16e932d2d4ad1e5ac6e/coverage-7.10.6-cp313-cp313t-win_arm64.whl", hash = "sha256:3fb99d0786fe17b228eab663d16bee2288e8724d26a199c29325aac4b0319b9b", size = 219757, upload-time = "2025-08-29T15:34:19.248Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/aa/76cf0b5ec00619ef208da4689281d48b57f2c7fde883d14bf9441b74d59f/coverage-7.10.6-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6008a021907be8c4c02f37cdc3ffb258493bdebfeaf9a839f9e71dfdc47b018e", size = 217331, upload-time = "2025-08-29T15:34:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/65/91/8e41b8c7c505d398d7730206f3cbb4a875a35ca1041efc518051bfce0f6b/coverage-7.10.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5e75e37f23eb144e78940b40395b42f2321951206a4f50e23cfd6e8a198d3ceb", size = 217607, upload-time = "2025-08-29T15:34:22.433Z" },
+    { url = "https://files.pythonhosted.org/packages/87/7f/f718e732a423d442e6616580a951b8d1ec3575ea48bcd0e2228386805e79/coverage-7.10.6-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0f7cb359a448e043c576f0da00aa8bfd796a01b06aa610ca453d4dde09cc1034", size = 248663, upload-time = "2025-08-29T15:34:24.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/52/c1106120e6d801ac03e12b5285e971e758e925b6f82ee9b86db3aa10045d/coverage-7.10.6-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c68018e4fc4e14b5668f1353b41ccf4bc83ba355f0e1b3836861c6f042d89ac1", size = 251197, upload-time = "2025-08-29T15:34:25.906Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ec/3a8645b1bb40e36acde9c0609f08942852a4af91a937fe2c129a38f2d3f5/coverage-7.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd4b2b0707fc55afa160cd5fc33b27ccbf75ca11d81f4ec9863d5793fc6df56a", size = 252551, upload-time = "2025-08-29T15:34:27.337Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/70/09ecb68eeb1155b28a1d16525fd3a9b65fbe75337311a99830df935d62b6/coverage-7.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cec13817a651f8804a86e4f79d815b3b28472c910e099e4d5a0e8a3b6a1d4cb", size = 250553, upload-time = "2025-08-29T15:34:29.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/80/47df374b893fa812e953b5bc93dcb1427a7b3d7a1a7d2db33043d17f74b9/coverage-7.10.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f2a6a8e06bbda06f78739f40bfb56c45d14eb8249d0f0ea6d4b3d48e1f7c695d", size = 248486, upload-time = "2025-08-29T15:34:30.897Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/65/9f98640979ecee1b0d1a7164b589de720ddf8100d1747d9bbdb84be0c0fb/coverage-7.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:081b98395ced0d9bcf60ada7661a0b75f36b78b9d7e39ea0790bb4ed8da14747", size = 249981, upload-time = "2025-08-29T15:34:32.365Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/55/eeb6603371e6629037f47bd25bef300387257ed53a3c5fdb159b7ac8c651/coverage-7.10.6-cp314-cp314-win32.whl", hash = "sha256:6937347c5d7d069ee776b2bf4e1212f912a9f1f141a429c475e6089462fcecc5", size = 220054, upload-time = "2025-08-29T15:34:34.124Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d1/a0912b7611bc35412e919a2cd59ae98e7ea3b475e562668040a43fb27897/coverage-7.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:adec1d980fa07e60b6ef865f9e5410ba760e4e1d26f60f7e5772c73b9a5b0713", size = 220851, upload-time = "2025-08-29T15:34:35.651Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2d/11880bb8ef80a45338e0b3e0725e4c2d73ffbb4822c29d987078224fd6a5/coverage-7.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:a80f7aef9535442bdcf562e5a0d5a5538ce8abe6bb209cfbf170c462ac2c2a32", size = 219429, upload-time = "2025-08-29T15:34:37.16Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c0/1f00caad775c03a700146f55536ecd097a881ff08d310a58b353a1421be0/coverage-7.10.6-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:0de434f4fbbe5af4fa7989521c655c8c779afb61c53ab561b64dcee6149e4c65", size = 218080, upload-time = "2025-08-29T15:34:38.919Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c4/b1c5d2bd7cc412cbeb035e257fd06ed4e3e139ac871d16a07434e145d18d/coverage-7.10.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6e31b8155150c57e5ac43ccd289d079eb3f825187d7c66e755a055d2c85794c6", size = 218293, upload-time = "2025-08-29T15:34:40.425Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/4468d37c94724bf6ec354e4ec2f205fda194343e3e85fd2e59cec57e6a54/coverage-7.10.6-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:98cede73eb83c31e2118ae8d379c12e3e42736903a8afcca92a7218e1f2903b0", size = 259800, upload-time = "2025-08-29T15:34:41.996Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d8/f8fb351be5fee31690cd8da768fd62f1cfab33c31d9f7baba6cd8960f6b8/coverage-7.10.6-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f863c08f4ff6b64fa8045b1e3da480f5374779ef187f07b82e0538c68cb4ff8e", size = 261965, upload-time = "2025-08-29T15:34:43.61Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/70/65d4d7cfc75c5c6eb2fed3ee5cdf420fd8ae09c4808723a89a81d5b1b9c3/coverage-7.10.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b38261034fda87be356f2c3f42221fdb4171c3ce7658066ae449241485390d5", size = 264220, upload-time = "2025-08-29T15:34:45.387Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3c/069df106d19024324cde10e4ec379fe2fb978017d25e97ebee23002fbadf/coverage-7.10.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e93b1476b79eae849dc3872faeb0bf7948fd9ea34869590bc16a2a00b9c82a7", size = 261660, upload-time = "2025-08-29T15:34:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/2974d53904080c5dc91af798b3a54a4ccb99a45595cc0dcec6eb9616a57d/coverage-7.10.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ff8a991f70f4c0cf53088abf1e3886edcc87d53004c7bb94e78650b4d3dac3b5", size = 259417, upload-time = "2025-08-29T15:34:48.779Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/9616a6b49c686394b318974d7f6e08f38b8af2270ce7488e879888d1e5db/coverage-7.10.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ac765b026c9f33044419cbba1da913cfb82cca1b60598ac1c7a5ed6aac4621a0", size = 260567, upload-time = "2025-08-29T15:34:50.718Z" },
+    { url = "https://files.pythonhosted.org/packages/76/16/3ed2d6312b371a8cf804abf4e14895b70e4c3491c6e53536d63fd0958a8d/coverage-7.10.6-cp314-cp314t-win32.whl", hash = "sha256:441c357d55f4936875636ef2cfb3bee36e466dcf50df9afbd398ce79dba1ebb7", size = 220831, upload-time = "2025-08-29T15:34:52.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e5/d38d0cb830abede2adb8b147770d2a3d0e7fecc7228245b9b1ae6c24930a/coverage-7.10.6-cp314-cp314t-win_amd64.whl", hash = "sha256:073711de3181b2e204e4870ac83a7c4853115b42e9cd4d145f2231e12d670930", size = 221950, upload-time = "2025-08-29T15:34:54.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/51/e48e550f6279349895b0ffcd6d2a690e3131ba3a7f4eafccc141966d4dea/coverage-7.10.6-cp314-cp314t-win_arm64.whl", hash = "sha256:137921f2bac5559334ba66122b753db6dc5d1cf01eb7b64eb412bb0d064ef35b", size = 219969, upload-time = "2025-08-29T15:34:55.83Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/50db5379b615854b5cf89146f8f5bd1d5a9693d7f3a987e269693521c404/coverage-7.10.6-py3-none-any.whl", hash = "sha256:92c4ecf6bf11b2e85fd4d8204814dc26e6a19f0c9d938c207c5cb0eadfcabbe3", size = 208986, upload-time = "2025-08-29T15:35:14.506Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -373,6 +437,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -616,6 +689,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
 name = "parse"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -631,6 +713,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -741,6 +832,48 @@ name = "pyperclip"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b63cdff36cd398d9701d26cda58e3ab97ac79fb5e60d/pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310", size = 20961, upload-time = "2024-06-18T20:38:48.401Z" }
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
 
 [[package]]
 name = "python-dotenv"
@@ -996,6 +1129,11 @@ dev = [
     { name = "ruff" },
     { name = "ty" },
 ]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1013,6 +1151,11 @@ requires-dist = [
 dev = [
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "ty", specifier = ">=0.0.1a16" },
+]
+test = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-mock", specifier = ">=3.12.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- pytestベースの包括的なテストフレームワークを導入
- 24のユニットテストで主要機能をカバー（カバレッジ48%）
- scripts.pyのcheck関数にテスト実行を統合

## Changes
- pytest、pytest-cov、pytest-mockの依存関係を追加
- pyproject.tomlにテスト設定とカバレッジ設定を追加
- 3つの主要モジュールのテストファイルを作成
  - test_config.py: 設定管理のテスト（6テスト）
  - test_server.py: サーバー機能のテスト（9テスト）
  - test_error_messages.py: エラーハンドリングのテスト（9テスト）
- conftest.pyでモックフィクスチャを提供
- uv run checkコマンドに型チェック・Lint・テストを統合

## Test plan
- [x] 全24テストが成功することを確認済み
- [x] uv run testコマンドでテスト実行可能
- [x] uv run checkコマンドで包括的品質チェック実行可能
- [x] カバレッジレポートがhtmlcov/で生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)