### PR TITLE
docs: add link to Japanese README in English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SharePoint Docs MCP Server
 
+> [🇯🇵 日本語版はこちら](README_ja.md)
+
 A Model Context Protocol (MCP) server that provides SharePoint document search functionality.
 Supports both stdio and HTTP transports.
 


### PR DESCRIPTION
## Summary

- Add prominent link to README_ja.md at the top of README.md
- Use Japanese flag emoji (🇯🇵) for visual clarity and easy identification
- Improve accessibility for Japanese-speaking users

## Changes

- Added language switcher at the beginning of the English README
- Follows common practice for multi-language documentation

## Preview

The link appears as:
> 🇯🇵 日本語版はこちら

🤖 Generated with [Claude Code](https://claude.ai/code)