### PR TITLE
feat(lint): Add automatic detection for function-level imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,13 +72,14 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "UP", # pyupgrade
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+    "PLC", # pylint conventions (includes PLC0415: import-outside-toplevel)
 ]
 ignore = [
     "E501",  # line too long, handled by black
@@ -89,6 +90,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"tests/**/*.py" = ["PLC0415"]  # Allow function-level imports in tests for mocking/isolation
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/sharepoint_auth.py
+++ b/src/sharepoint_auth.py
@@ -7,6 +7,7 @@ import logging
 import time
 import uuid
 from pathlib import Path
+from urllib.parse import urlparse
 
 import jwt
 import requests
@@ -132,8 +133,6 @@ class SharePointCertificateAuth:
             )
 
             # SharePointサイトのテナント名を取得
-            from urllib.parse import urlparse
-
             parsed_url = urlparse(self.site_url)
             tenant_name = parsed_url.netloc.split(".sharepoint.com")[0]
             scope = f"https://{tenant_name}.sharepoint.com/.default"


### PR DESCRIPTION
## 概要

関数内import（PEP 8違反）を自動検出するruffルールを追加しました。

## 背景

PR #36でGemini Code Assistから指摘を受けた関数内importの問題を、今後自動的に検出できるようにします。

## 変更内容

### ruff設定の強化（`pyproject.toml`）
- `PLC` (pylint conventions) ルールグループを追加
  - `PLC0415` (import-outside-toplevel) を含む
- テストファイルでは `PLC0415` を除外
  - 環境変数の再読み込み、モックの順序制御など、テストで正当な理由がある場合を考慮

### 既存コードの修正（`src/sharepoint_auth.py`）
- 関数内で使用していた `from urllib.parse import urlparse` をファイル先頭に移動

## 検証

### 本番コードでの検出
```bash
$ uv run ruff check src/ --select PLC0415
All checks passed!
```

### テストコードでは除外
```bash
$ uv run ruff check tests/ --select PLC0415
All checks passed!  # per-file-ignoresで除外されている
```

### 品質チェック
- ✅ 型チェック（ty）: PASS
- ✅ Lint（ruff）: PASS
- ✅ テスト（pytest）: PASS

## 効果

今後、本番コード（`src/`）で関数内importを使用すると、`uv run check` や `uv run lint` で自動的に検出されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)